### PR TITLE
Support GHC 9.8

### DIFF
--- a/alex-tools.cabal
+++ b/alex-tools.cabal
@@ -1,3 +1,4 @@
+cabal-version:       3.4
 name:                alex-tools
 version:             0.6.1
 synopsis:            A set of functions for a common use case of Alex.
@@ -10,7 +11,6 @@ copyright:           Iavor S. Diatchki, 2016
 category:            Development
 build-type:          Simple
 extra-source-files:  ChangeLog.md
-cabal-version:       >=1.10
 
 source-repository head
   type: git
@@ -19,11 +19,11 @@ source-repository head
 library
   exposed-modules:     AlexTools, AlexToolsBin
   other-extensions:    TemplateHaskell
-  build-depends:       base >=4.7 && <4.19,
+  build-depends:       base >=4.7 && <4.20,
                        text >= 1.2.4 && < 2.1,
                        bytestring >= 0.9 && <0.12,
-                       deepseq >=1.3 && <1.5,
-                       template-haskell >=2.9.0 && <2.21
+                       deepseq >=1.3 && <1.6,
+                       template-haskell >=2.9.0 && <2.22
   hs-source-dirs:      src
   ghc-options:         -Wall
   default-language:    Haskell2010


### PR DESCRIPTION
This PR bumps the bounds to support GHC 9.8. 

@yav: I can integrate a CI setup that uses the cabal file `tested-with` stanza to generate test jobs, if you want. 