### PR TITLE
Reduce minimum supported cabal version requirement.

### DIFF
--- a/alex-tools.cabal
+++ b/alex-tools.cabal
@@ -1,4 +1,4 @@
-cabal-version:       3.4
+cabal-version:       2.0
 name:                alex-tools
 version:             0.6.1
 synopsis:            A set of functions for a common use case of Alex.


### PR DESCRIPTION
This is a very simple cabal file, and not all installations are compatible with a minimum cabal version of 3.4.  The minimum version could probably be even lower if even older configurations need to be supported.